### PR TITLE
Handle file separator for any OS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ function fileNamePrefix (options = {}) {
     let fileName = path.basename(filePath)
     let [name] = fileName.split('.')
     if (name === 'index') {
-      let parts = filePath.split('/')
+      let parts = filePath.split(path.sep)
       name = parts[parts.length - 2]
     }
 


### PR DESCRIPTION
On windows the filepath has "\\" and on linux/mac the filepath has "/". This change makes it work on any OS, because right now it has issues on Windows.