### PR TITLE
Improvement: ignore css module files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Ignores:
 - filenames that starts from not capital letter
 - modifiers (classes that starts from hyphen)
 - classes that starts from capital letter
+- css module files
 
 ## Installation
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ function fileNamePrefix (options = {}) {
       name = parts[parts.length - 2]
     }
 
-    if (ignoreFileName(name)) return
+    if (ignoreFileName(fileName)) return
 
     let prefix = name + '-'
 
@@ -36,7 +36,9 @@ function fileNamePrefix (options = {}) {
 }
 
 function ignoreFileName (fileName) {
-  return /^[^A-Z]/.test(fileName)
+  // ignore files not beginning with capital letter
+  // ignore css module files to avoid conflict
+  return /^[^A-Z]/.test(fileName) || /(?:\.module).(css|sass|scss|less|styl)(?:.*)$/.test(fileName);
 }
 
 function ignoreClassName (className, options) {


### PR DESCRIPTION
I didn't add a feature flag for this rather choose to ignore by default, because I don't think anyone will ever need to use this plugin on css module files.